### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.3.1
+
+services:
+  - redis-server
+
+addons:
+  postgresql: 9.3
+
+before_script:
+  - bundle exec rake db:create db:migrate db:seed
+
+script:
+  - bundle exec rspec
+  - bundle exec rubocop


### PR DESCRIPTION
This PR adds a `.travis.yml` file to configure Travis CI to run our tests and run rubocop.  It depends on #4 and #5 to merge before Travis will start reporting successful builds.

Here's some info on what each of the settings does:

```yaml
# This sets the programming language environment to Ruby
language: ruby

# This tells Travis to cache the gems installed via bundler (the Gemfile) so that
# it doesn't have to redownload them for each and every build
cache: bundler

# This sets the version of Ruby to use
rvm:
  - 2.3.1

# This installs a Redis server (in case we need it, which we probably won't, but in case we do)
services:
  - redis-server

# This sets the PostgreSQL database version
addons:
  postgresql: 9.3

# This is run before the tests are run, and we're using it to create the database from the migrations
before_script:
  - bundle exec rake db:create db:migrate db:seed

# This specifies what the test commands are.  For our project, we are running rspec and rubocop
script:
  - bundle exec rspec
  - bundle exec rubocop
```
