### PR TITLE
Fix MetricsAbcSize rubocop error in game.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,5 +29,4 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Enabled: false
 
-Metrics/AbcSize:
-  Enabled: false
+

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -24,6 +24,7 @@ class Game < ApplicationRecord
   end
 
   # rubocop:disable MethodLength
+  # rubocop:disable Metrics/AbcSize
   def initialize_board
     # Building out white pieces
     (0..7).each do |x|


### PR DESCRIPTION
This adds a comment to disable MetricsAbcSize just while we're initiating a game (without disabling it in .rubocop.yml), to fix a rubocop error.